### PR TITLE
Refactor/jenkins.yaml location

### DIFF
--- a/experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
+++ b/experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
@@ -3,5 +3,5 @@ USER jenkins
 RUN echo "2.0" > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
-COPY jenkins.yaml /var/jenkins_home/casc_configs/jenkins.yaml
+COPY jenkins.yaml /usr/share/jenkins/ref/jenkins.yaml
 ENV CASC_JENKINS_CONFIG /var/jenkins_home/casc_configs/jenkins.yaml

--- a/experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
+++ b/experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
@@ -4,4 +4,3 @@ RUN echo "2.0" > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
 COPY jenkins.yaml /usr/share/jenkins/ref/jenkins.yaml
-ENV CASC_JENKINS_CONFIG /var/jenkins_home/casc_configs/jenkins.yaml


### PR DESCRIPTION
- fixes #31 
- I've deleted the `ENV CASC_JENKINS_CONFIG` from the Dockerfile but it's still working fine, I understand if it works without CASC env with `$JENKINS_HOME/` since it's default but how is it working with `/usr/share/jenkins/ref/`, does it take this directory as default too?    
- pinging mentors @gounthar @jmMeessen @berviantoleo 