### PR TITLE
feature(maven): Creates a fork and a local clone

### DIFF
--- a/experimental_docker_compose_files/maven/Dockerfile
+++ b/experimental_docker_compose_files/maven/Dockerfile
@@ -1,0 +1,26 @@
+# Use a base image
+FROM debian:bookworm-20230612 as cloning-stage
+
+# Set ARGs for the GitHub credentials and repository
+ARG GITHUB_USERNAME
+ARG GITHUB_PASSWORD
+ARG REPO_NAME=jenkins-docs/simple-java-maven-app
+
+# Install Git and gh
+RUN apt-get update && \
+    apt-get install -y curl git && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt update && apt install gh -y
+
+# Clone the repository
+RUN cd /tmp && \
+    echo "$GITHUB_PASSWORD" | gh auth login --with-token && \
+    gh repo fork "$REPO_NAME" --clone=true --remote=true --default-branch-only=true && \
+    pwd && \
+    ls -artl
+
+
+FROM scratch AS export-stage
+COPY --from=cloning-stage /tmp/simple-java-maven-app /

--- a/experimental_docker_compose_files/maven/fork-and-clone.sh
+++ b/experimental_docker_compose_files/maven/fork-and-clone.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 MAVEN_REPO="jenkins-docs/simple-java-maven-app"
+# Extract the repository name from MAVEN_REPO
+REPO_NAME=${MAVEN_REPO##*/}
 
 # Create a directory on the host machine to store the cloned repository
-CLONE_DIR=$(pwd)/cloned-repo
+CLONE_DIR=$(pwd)/$REPO_NAME
 
 # Prompt for GitHub credentials
 read -p "Enter your GitHub username: " GITHUB_USERNAME

--- a/experimental_docker_compose_files/maven/fork-and-clone.sh
+++ b/experimental_docker_compose_files/maven/fork-and-clone.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+MAVEN_REPO="jenkins-docs/simple-java-maven-app"
+
+# Create a directory on the host machine to store the cloned repository
+CLONE_DIR=$(pwd)/cloned-repo
+
+# Prompt for GitHub credentials
+read -p "Enter your GitHub username: " GITHUB_USERNAME
+read -s -p "Enter your GitHub password or personal access token: " GITHUB_PASSWORD
+echo
+
+# Create the destination directory
+mkdir -p $CLONE_DIR
+
+# Build the Docker image
+DOCKER_BUILD_ARGS="--build-arg GITHUB_USERNAME=$GITHUB_USERNAME --build-arg GITHUB_PASSWORD=$GITHUB_PASSWORD --build-arg REPO_NAME=$MAVEN_REPO --file=Dockerfile --tag=clone-result --progress=plain --output $CLONE_DIR ."
+docker build $DOCKER_BUILD_ARGS
+
+# Clean up the credentials
+unset GITHUB_USERNAME
+unset GITHUB_PASSWORD


### PR DESCRIPTION
@ash-sxn @berviantoleo @jmMeessen 

The [first part](https://www.jenkins.io/doc/tutorials/build-a-java-app-with-maven/#run-jenkins-in-docker) of the tutorial is already covered by the current state of the project.

## What does this PR do?

This is a draft pull request to see if one of the mandatory steps for #39 can be simplified.
This addresses [this part](https://www.jenkins.io/doc/tutorials/build-a-java-app-with-maven/#fork-and-clone-the-sample-repository-on-github) of the existing documentation.

The fork/clone/git is kind of protracted and complex.
The first step I see is the use of a simple bash script that uses a docker build to produce locally a cloned version of the maven sample repo. It also forks the maven sample repo on the user's GitHub account.

The script asks you for your GitHub username and a password (token) and then builds a temporary Docker image that outputs on the host (locally) a directory of the fork, ready to be modified.
You then have a `simple-java-maven-app` directory you could use as a volume in your `docker-compose.yaml`.

This way, the end user does not have to configure git or gh, or fork on the GitHub website, all is done thanks to Docker.
I'm pretty thrilled with this output.

Does it work on macOS and Linux? I do hope so.
It worked on my WSL2 and under GitPod.

## What is the next step?

The [next step](https://www.jenkins.io/doc/tutorials/build-a-java-app-with-maven/#create-your-pipeline-project-in-jenkins) in the existing documentation is to create the pipeline project in Jenkins.
My idea is to create it once manually, and then copy/paste the resulting job in the repo, clean it up, and put variables in it instead of the hardcoded values (mostly about the repo).
Then, we would add another `bash` script to dynamize these values (maybe thanks to before launching the `docker compose up --build` command.
For this step, as we may have a very limited set of tools installed on the end-user host, we could also use a transient docker image to get the job done (thanks to `xsltc`, `sed` or `python`).
The existing documentation still uses `maven:3.9.0-eclipse-temurin-11` but of course, we would use something more recent like `maven:3.9.2-eclipse-temurin-17-alpine`.
