### PR TITLE
(bug): dirty git work tree, (chore): update to new jenkins image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore secrets folder
 secrets/*
 experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/secrets/*
+.tutorial_running.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore secrets folder
+secrets/*
+experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/secrets/*
+# Ignore dockerfiles because get's changed during the gitpodURL.sh
+dockerfiles/jenkins.yaml
+experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/jenkins.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 # Ignore secrets folder
 secrets/*
 experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/secrets/*
-# Ignore dockerfiles because get's changed during the gitpodURL.sh
-dockerfiles/jenkins.yaml
-experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/jenkins.yaml

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.401.1-lts
+FROM jenkins/jenkins:2.401.2-lts
 USER root
 COPY jobs /var/jenkins_home/jobs
 RUN chown -R jenkins:jenkins /var/jenkins_home/jobs

--- a/experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
+++ b/experimental_docker_compose_files/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.401.1-lts
+FROM jenkins/jenkins:2.401.2-lts
 USER root
 COPY jobs /var/jenkins_home/jobs
 RUN chown -R jenkins:jenkins /var/jenkins_home/jobs

--- a/jenkins_teardown.sh
+++ b/jenkins_teardown.sh
@@ -30,6 +30,8 @@ stop_tutorial() {
     docker compose -f "$tutorial_path/docker-compose.yaml" down --volumes
   fi
   head -n -1 .tutorials_running.txt > temp.txt ; mv temp.txt .tutorials_running.txt
+
+  git restore "$tutorial_path/docker-compose.yaml"
 }
 
 # Loop through the running tutorials and stop them


### PR DESCRIPTION
- resolves #48 
- update jenkins/jenkins:  20.401.1-lts => 20.401.2-lts
- the completes Milestone 0
- this uses `git restore docker-compose.yaml` in jenkins_teardown.sh to deal with docker-compose.yaml's git issue  
- #55  was also fixed from `jenkins_teardown.sh`, I forgot to add it in the PR, should I add it to this one? 
- pinging mentors @berviantoleo @gounthar @jmMeessen 