### PR TITLE
Use Java 17 and the --build arg

### DIFF
--- a/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
+++ b/02_custom_docker_file_connecting_agent_and_controller/dockerfiles/Dockerfile
@@ -1,9 +1,9 @@
-FROM jenkins/jenkins:2.401.2-lts
+FROM jenkins/jenkins:2.401.2-jdk17
 USER root
 COPY jobs /var/jenkins_home/jobs
 RUN chown -R jenkins:jenkins /var/jenkins_home/jobs
 USER jenkins
-RUN echo "2.0" > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
+RUN echo "2.401.2" > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
 COPY jenkins.yaml /usr/share/jenkins/ref/jenkins.yaml

--- a/jenkins_init.sh
+++ b/jenkins_init.sh
@@ -110,7 +110,7 @@ generate_ssh_keys() {
 start_tutorial() {
   local tutorial_path=$1
   echo "Starting tutorial $tutorial_path"
-  $DOCKER_COMPOSE -f "$tutorial_path/docker-compose.yaml" up -d
+  $DOCKER_COMPOSE -f "$tutorial_path/docker-compose.yaml" up -d --build
 }
 
 # check wsl


### PR DESCRIPTION
## Use Java 17 and compose with the --build arg

- Use Java 17
- Compose with --build arg

Without the `--build` arg, changes to the container definition are not rebuilt.
