### PR TITLE
Set shell file end of line convention

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.sh text elo=lf
+*.sh text eol=lf


### PR DESCRIPTION
Windows users will need to clone a new copy of the repository.