### PR TITLE
adding if condition & input id

### DIFF
--- a/05_nodejs/README.md
+++ b/05_nodejs/README.md
@@ -79,14 +79,14 @@ This tutorial utilizes two Docker containers with a custom SSH agent to demonstr
                 sh './jenkins/scripts/deliver.sh' 
                 // Remove the initial 'https://' and prepend 'https://3000-' to the URL.
                 script {
-                    def modifiedUrl = 'https://3000-' + env.GITPOD_WORKSPACE_URL.substring('https://'.length())
-                    echo "If you are using Gitpod use this link instead ${modifiedUrl}"
+                    if (env.GITPOD_WORKSPACE_URL) {
+                        def modifiedUrl = 'https://3000-' + env.GITPOD_WORKSPACE_URL.substring('https://'.length())
+                        echo "If you are using Gitpod use this link instead ${modifiedUrl}"
+                    }
                 }
-
-                input message: 'Finished using the website? (Click "Proceed" to continue)' 
-                sh './jenkins/scripts/kill.sh' 
+                input id: 'PROCEED', message: 'Finished using the website? (Click "Proceed" to continue)' 
+                sh './jenkins/scripts/kill.sh'  
             }
-        }
         ```
   - Run the command `git add .` to add the edited `Jenkinsfile` to the staging, then run `git commit -m "Add 'Deliver' stage"` to commit the changes. Afterward, run `git push origin master` to push the changes to your forked repository.
   - Press the "Build Now" button again to run the Build, Test, and Deliver stages.


### PR DESCRIPTION
- I found out while testing for #157 that the node tutorial was not working on my local setup but was working on gitpod 
- It was because the new GITPOD_WORKSPACE_URL variable was empty in local setup which was causing the error in the pipeline
- So I've added the if condition
- I've also set an input id to the PROCEED button whose input is required to complete the node tutorial
- So It can be completed in GitHub action with curl command  