### PR TITLE
adding  & updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ It can be found [here](https://chrome.google.com/webstore/detail/gitpod-online-i
     * `python` - 04_python-tutorial => `docker compose up -d python`
     * `node` - 05_nodejs => `docker compose up -d node`
 * If no argument is used i.e. `docker compose up -d`, it runs the latest default example.
+* The above command uses prebuild images, which is not always secure to pull for unknow source.
+* So If you want to build images yourself add `-f build-docker-compose.yaml` after `docker compose`
+* eventually to make the command look something liks this `docker compose -f build-docker-compose.yaml up -d node` for build the Node Tutorial.
 
 ### How to Verify Jenkins Installation
 * You can check the status of the container with the `docker ps` command or the `docker compose ps` one.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ It can be found [here](https://chrome.google.com/webstore/detail/gitpod-online-i
     * `python` - 04_python-tutorial => `docker compose up -d python`
     * `node` - 05_nodejs => `docker compose up -d node`
 * If no argument is used i.e. `docker compose up -d`, it runs the latest default example.
-* The above command uses prebuild images, which is not always secure to pull for unknow source.
+* The above command utilizes prebuilt images, which you might want to be cautious about as their source is not currently known or part of the Jenkins CI organization.
 * So If you want to build images yourself add `-f build-docker-compose.yaml` after `docker compose`
-* eventually to make the command look something liks this `docker compose -f build-docker-compose.yaml up -d node` for build the Node Tutorial.
+* Eventually, the command should resemble something like this: `docker compose -f build-docker-compose.yaml up -d node` to build the Node Tutorial.
 
 ### How to Verify Jenkins Installation
 * You can check the status of the container with the `docker ps` command or the `docker compose ps` one.

--- a/build-docker-compose.yaml
+++ b/build-docker-compose.yaml
@@ -1,0 +1,111 @@
+services:
+  sidekick_service:
+    # Configuration for the sidekick service
+    build: dockerfiles/sidekick/.
+    stdin_open: true
+    tty: true
+    entrypoint: sh -c "/usr/local/bin/keygen.sh /ssh-dir"  # Runs the keygen.sh script and specifies the output directory
+    volumes:
+      - agent-ssh-dir:/ssh-dir  # Mounts the agent-ssh-dir volume to the /ssh-dir path inside the container
+    healthcheck:
+      test: [ "CMD-SHELL", "[ -f /ssh-dir/conductor_ok ] || exit 1" ]  # Checks if the conductor_ok file exists in the /ssh-dir path
+      interval: 5s
+      timeout: 10s
+      retries: 5
+
+  jenkins_controller:
+    build: dockerfiles/.
+    restart: on-failure
+    ports:
+      - "8080:8080"
+    volumes:
+      - jenkins_home:/var/jenkins_home  # Mounts the jenkins_home volume to the /var/jenkins_home path inside the container
+      - agent-ssh-dir:/ssh-dir  # Mounts the agent-ssh-dir volume to the /app path inside the container
+    depends_on:
+      sidekick_service:
+        condition: service_completed_successfully  # Depends on the successful completion of the sidekick_service
+    healthcheck:
+      test: [ "CMD-SHELL", "[ -f /ssh-dir/conductor_ok ] || exit 1" ]  # Checks if the conductor_ok file exists in the /ssh-dir path
+      interval: 5s
+      timeout: 10s
+      retries: 5
+
+  default_agent:
+    image: jenkins/ssh-agent:5.5.0-jdk17
+    container_name: desktop-jenkins_agent-1
+    depends_on:
+      sidekick_service:
+        condition: service_completed_successfully  # Depends on the successful completion of the sidekick_service
+      jenkins_controller:
+        condition: service_started 
+    healthcheck:
+      test: [ "CMD-SHELL", "[ -f /home/jenkins/.ssh/authorized_keys ] || exit 1" ]  # Checks if the authorized_keys file exists in the /home/jenkins/.ssh path
+      interval: 5s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - agent-ssh-dir:/home/jenkins/.ssh:ro  # Mounts the agent-ssh-dir volume to the /home/jenkins/.ssh path inside the container as read-only
+
+  maven:
+    build: dockerfiles/maven/.
+    container_name: desktop-jenkins_agent-1
+    profiles:
+      - maven
+    depends_on:
+      sidekick_service:
+        condition: service_completed_successfully  # Depends on the successful completion of the sidekick_service
+      jenkins_controller:
+        condition: service_started 
+    healthcheck:
+      test: [ "CMD-SHELL", "[ -f /home/jenkins/.ssh/authorized_keys ] || exit 1" ]  # Checks if the authorized_keys file exists in the /home/jenkins/.ssh path
+      interval: 5s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - agent-ssh-dir:/home/jenkins/.ssh:ro  # Mounts the agent-ssh-dir volume to the /home/jenkins/.ssh path inside the container as read-only
+
+  python:
+    build: dockerfiles/python/.
+    container_name: desktop-jenkins_agent-1
+    profiles:
+      - python
+    depends_on:
+      sidekick_service:
+        condition: service_completed_successfully  # Depends on the successful completion of the sidekick_service
+      jenkins_controller:
+        condition: service_started 
+    healthcheck:
+      test: [ "CMD-SHELL", "[ -f /home/jenkins/.ssh/authorized_keys ] || exit 1" ]  # Checks if the authorized_keys file exists in the /home/jenkins/.ssh path
+      interval: 5s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - agent-ssh-dir:/home/jenkins/.ssh:ro  # Mounts the agent-ssh-dir volume to the /home/jenkins/.ssh path inside the container as read-only
+
+  node:
+    build: dockerfiles/node/.
+    environment:
+      - GITPOD_WORKSPACE_URL=${GITPOD_WORKSPACE_URL}    
+    container_name: desktop-jenkins_agent-1
+    profiles:
+      - node
+    depends_on:
+      sidekick_service:
+        condition: service_completed_successfully  # Depends on the successful completion of the sidekick_service
+      jenkins_controller:
+        condition: service_started 
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: [ "CMD-SHELL", "[ -f /home/jenkins/.ssh/authorized_keys ] || exit 1" ]  # Checks if the authorized_keys file exists in the /home/jenkins/.ssh path
+      interval: 5s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - agent-ssh-dir:/home/jenkins/.ssh:ro  # Mounts the agent-ssh-dir volume to the /home/jenkins/.ssh path inside the container as read-only
+    
+
+volumes:
+  jenkins_home:
+  agent-ssh-dir:
+    name: agent-ssh-dir  # Creates a named volume called agent-ssh-dir


### PR DESCRIPTION
- fixes #161 
- Created a copy of `docker-compose.yaml` with build steps instead of images
- Which can be used by adding ` -f build-docker-compose.yaml` to the command `docker compose up -d` command to make this `docker compsoe -f build-docker-compose.yaml up -d`
- Updated the Readme file too