### PR TITLE
fix(docker): Node install script is not supported anymore.

### DIFF
--- a/dockerfiles/node/Dockerfile
+++ b/dockerfiles/node/Dockerfile
@@ -1,13 +1,13 @@
 FROM jenkins/ssh-agent:5.12.0-jdk17 as ssh-agent
-# ca-certificates because curl will need it later on for the maven installation
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+ARG NODE_MAJOR=18
 
-# Installing curl
-RUN apt-get update && apt-get install -y curl
-
-# Installing nodejs
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
+# ca-certificates because curl will need it later on for the node installation
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    # Installing nodejs
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && apt-get install nodejs -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set SHELL flags for RUN commands to allow -e and pipefail
 # Rationale:https://github.com/hadolint/hadolint/wiki/DL4006


### PR DESCRIPTION
See https://github.com/nodesource/distributions#installation-instructions .